### PR TITLE
Repair the update method code error caused by the primary key field being clearly not id

### DIFF
--- a/template/1.3.4/model/update.tpl
+++ b/template/1.3.4/model/update.tpl
@@ -1,6 +1,6 @@
 
 func (m *default{{.upperStartCamelObject}}Model) Update(ctx context.Context, data *{{.upperStartCamelObject}}) error {
-	{{if .withCache}}old, err := m.FindOne(ctx, data.Id)
+	{{if .withCache}}old, err := m.FindOne(ctx, data.{{.upperStartCamelPrimaryKey}})
     if err != nil && err != ErrNotFound {
         return err
     }

--- a/template/1.4.2/model/update.tpl
+++ b/template/1.4.2/model/update.tpl
@@ -1,6 +1,6 @@
 
 func (m *default{{.upperStartCamelObject}}Model) Update(ctx context.Context, tx *gorm.DB, data *{{.upperStartCamelObject}}) error {
-    {{if .withCache}}old, err := m.FindOne(ctx, data.Id)
+    {{if .withCache}}old, err := m.FindOne(ctx, data.{{.upperStartCamelPrimaryKey}})
     if err != nil && err != ErrNotFound {
         return err
     }


### PR DESCRIPTION
Repair the update method code error caused by the primary key field being clearly not id