### PR TITLE
feat: support custom type mapping in goctl templates

### DIFF
--- a/template/1.7.0/model/import-no-cache.tpl
+++ b/template/1.7.0/model/import-no-cache.tpl
@@ -5,4 +5,6 @@ import (
 	{{if .time}}"time"{{end}}
 
 	"gorm.io/gorm"
+
+	{{.third}}
 )

--- a/template/1.7.0/model/import.tpl
+++ b/template/1.7.0/model/import.tpl
@@ -8,4 +8,6 @@ import (
 	"github.com/SpectatorNan/gorm-zero/gormc"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"gorm.io/gorm"
+
+	{{.third}}
 )

--- a/template/1.7.4/model/import-no-cache.tpl
+++ b/template/1.7.4/model/import-no-cache.tpl
@@ -5,4 +5,6 @@ import (
 	{{if .time}}"time"{{end}}
 
 	"gorm.io/gorm"
+
+	{{.third}}
 )

--- a/template/1.7.4/model/import.tpl
+++ b/template/1.7.4/model/import.tpl
@@ -9,4 +9,6 @@ import (
 	"github.com/SpectatorNan/gorm-zero/gormc/pagex"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"gorm.io/gorm"
+
+	{{.third}}
 )


### PR DESCRIPTION
Updated the templates for goctl version 1.7.0 and above to enable custom type mapping functionality. This enhancement leverages the experimental feature introduced in goctl version 1.6.5, allowing developers to define custom type mappings, thereby increasing flexibility and adaptability in project development.The changes align with the documentation provided at [go-zero documentation](https://go-zero.dev/en/docs/tutorials/cli/model#type-mapping-customization).