### PR TITLE
pagex下的FindPageListWithCount方法,支持多列字段排序

### DIFF
--- a/gormc/pagex/pageCombine.go
+++ b/gormc/pagex/pageCombine.go
@@ -2,6 +2,7 @@ package pagex
 
 import (
 	"context"
+
 	"github.com/SpectatorNan/gorm-zero/gormc"
 	"gorm.io/gorm"
 )
@@ -66,8 +67,8 @@ func FindPageList[T any](ctx context.Context, cc GormcCacheConn, page *ListReq, 
 // FindPageList
 // fn first return db, second return countDb, if count sql need special handler (example: distinct on column), you can return countDb
 // if countDb is nil, default count is first db
-func FindPageListWithCount[T any](ctx context.Context, page *ListReq, orderBy OrderBy,
-	orderKeys map[string]string, fn func() (*gorm.DB, *gorm.DB)) ([]T, int64, error) {
+func FindPageListWithCount[T any](ctx context.Context, page *ListReq, orderBy []OrderBy,
+	fn func() (*gorm.DB, *gorm.DB)) ([]T, int64, error) {
 	var res []T
 	var count int64
 
@@ -87,13 +88,16 @@ func FindPageListWithCount[T any](ctx context.Context, page *ListReq, orderBy Or
 		return nil, 0, err
 	}
 	db = db.Scopes(Paginate(page))
-	if orderStr, ok := orderKeys[orderBy.OrderKey]; ok {
-		if orderBy.Sort == tableSortDesc {
-			db = db.Order(orderStr + " desc")
-		} else {
-			db = db.Order(orderStr + " asc")
-		}
+	for _, odb := range orderBy {
+		db = db.Order(odb.OrderKey + " " + odb.Sort)
 	}
+	// if orderStr, ok := orderKeys[orderBy.OrderKey]; ok {
+	// 	if orderBy.Sort == tableSortDesc {
+	// 		db = db.Order(orderStr + " desc")
+	// 	} else {
+	// 		db = db.Order(orderStr + " asc")
+	// 	}
+	// }
 	err = db.Find(&res).Error
 
 	//err = cc.QueryNoCacheCtx(ctx, &res, func(conn *gorm.DB, v interface{}) error {

--- a/gormc/pagex/pagex_test.go
+++ b/gormc/pagex/pagex_test.go
@@ -1,0 +1,87 @@
+package pagex
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+type mysqlcfg struct {
+	Path         string // 服务器地址
+	Port         string `json:",default=3306"`                                               // 端口
+	Config       string `json:",default=charset%3Dutf8mb4%26parseTime%3Dtrue%26loc%3DLocal"` // 高级配置
+	Dbname       string // 数据库名
+	Username     string // 数据库用户名
+	Password     string // 数据库密码
+	MaxIdleConns int    `json:",default=10"` // 空闲中的最大连接数
+	MaxOpenConns int    `json:",default=10"` // 打开到数据库的最大连接数
+	LogMode      string `json:",default="`   // 是否开启Gorm全局日志
+	LogZap       bool   // 是否通过zap写入日志文件
+}
+
+func (m *mysqlcfg) Dsn() string {
+	return m.Username + ":" + m.Password + "@tcp(" + m.Path + ":" + m.Port + ")/" + m.Dbname + "?" + m.Config
+}
+
+type TestUserModel struct {
+	Id       uint64 `gorm:"column:id;primary_key"`
+	Age      int8   `gorm:"column:age"`
+	Name     string `gorm:"column:name"`     // The username
+	Nickname string `gorm:"column:nickname"` // The nickname
+	Avatar   string `gorm:"column:avatar"`
+	Email    string `gorm:"column:email"`
+}
+
+func (TestUserModel) TableName() string {
+	return "user"
+}
+
+func TestPagexFindPageList(t *testing.T) {
+	cfg := mysqlcfg{
+		Path:     "localhost",
+		Port:     "3306",
+		Config:   "charset%3Dutf8mb4%26parseTime%3Dtrue%26loc%3DLocal",
+		Dbname:   "gormzero",
+		Username: "root",
+		Password: "123456",
+	}
+	mcg := mysql.Config{
+		DSN: cfg.Dsn(),
+	}
+
+	db, err := gorm.Open(mysql.New(mcg))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// ccf := cache.CacheConf{
+	// 	cache.NodeConf{
+	// 		RedisConf: redis.RedisConf{
+	// 			Host: "127.0.0.1:6379",
+	// 			Pass: "",
+	// 		},
+	// 		Weight: 100,
+	// 	},
+	// }
+	// gormc := gormc.NewConn(db, ccf)
+	users, cnt, err := FindPageListWithCount[TestUserModel](
+		context.Background(),
+		&ListReq{Page: 1, PageSize: 5},
+		[]OrderBy{
+			{OrderKey: "age", Sort: "asc"},
+			{OrderKey: "id", Sort: "desc"},
+		},
+		func() (*gorm.DB, *gorm.DB) {
+			db := db.Model(&TestUserModel{})
+			return db, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("TestPagexFindPageList Err,%v", err.Error())
+	}
+	fmt.Println(users, cnt)
+}


### PR DESCRIPTION
因为业务需求需要在查询列表的地方按照多个字段排序，发现原来的FindPageListWithCount方法不支持多个字段排序，而且在调用方法的时候，稍微有些麻烦，因此小小的优化了一下代码。